### PR TITLE
XML parsing error with last_response

### DIFF
--- a/lib/cucumber/api_steps.rb
+++ b/lib/cucumber/api_steps.rb
@@ -64,10 +64,10 @@ Then /^the JSON response should (not)?\s?have "([^"]*)" with the text "([^"]*)"$
 end
 
 Then /^the XML response should have "([^"]*)" with the text "([^"]*)"$/ do |xpath, text|
-  parsed_response = Nokogiri::XML(last_response.body)
+  parsed_response = Nokogiri::XML(page.body)
   elements = parsed_response.xpath(xpath)
   if page.respond_to?(:should)
-    elements.should_not be_empty, "could not find #{xpath} in:\n#{last_response.body}"
+    elements.should_not be_empty, "could not find #{xpath} in:\n#{page.body}"
     elements.find { |e| e.text == text }.should_not be_nil, "found elements but could not find #{text} in:\n#{elements.inspect}"
   else
     assert !elements.empty?, "could not find #{xpath} in:\n#{last_response.body}"


### PR DESCRIPTION
When using the existing steps, I was getting the following error:

```
No response yet. Request a page first. (Rack::Test::Error)
```

Changing `last_response.body` to `page.body` fixed this problem.
