### PR TITLE
Allow user to set custom 'Accept' header

### DIFF
--- a/lib/cucumber/api_steps.rb
+++ b/lib/cucumber/api_steps.rb
@@ -13,6 +13,10 @@ if defined?(Rack)
 
 end
 
+Given /^I send and accept "(.*?)"$/ do |type|
+  page.driver.header 'Accept', type
+end
+
 Given /^I send and accept (XML|JSON)$/ do |type|
   page.driver.header 'Accept', "application/#{type.downcase}"
   page.driver.header 'Content-Type', "application/#{type.downcase}"


### PR DESCRIPTION
According to this railscast http://railscasts.com/episodes/350-rest-api-versioning api version is set by 'Accept' header.
Github uses this convention http://developer.github.com/.
