### PR TITLE
Fix required ruby version to >= 1.9.3

### DIFF
--- a/cucumber-api-steps.gemspec
+++ b/cucumber-api-steps.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Cucumber steps to easily test REST-based XML and JSON APIs}
   s.description = %q{Cucumber steps to easily test REST-based XML and JSON APIs}
 
-  s.required_ruby_version = '~> 1.9.3'
+  s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency              'jsonpath', '>= 0.1.2'
   s.add_dependency              'cucumber',  '>= 1.2.1'


### PR DESCRIPTION
The prior version specification `'~>'` was limiting ruby versions to 1.9.X and so ruby 2.0 and 2.1 were not compatible.

This caused the following error:

```
Installing cucumber-api-steps (0.12) 
Gem::InstallError: cucumber-api-steps requires Ruby version ~> 1.9.3.
An error occurred while installing cucumber-api-steps (0.12), and Bundler cannot continue.
Make sure that `gem install cucumber-api-steps -v '0.12'` succeeds before bundling.
```

See http://guides.rubygems.org/specification-reference/#required_ruby_version=

_Note that `bundler` does not complain when using the gem from source (path or git) but only when trying to get it as a gem from rubygems._
