### PR TITLE
Fix link to Cucumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/jayzes/cucumber-api-steps.png)](https://travis-ci.org/jayzes/cucumber-api-steps)
 [![Gem Version](https://badge.fury.io/rb/cucumber-api-steps.png)](http://badge.fury.io/rb/cucumber-api-steps)
 
-A set of [Cucumber](https://github.com/aslakhellesoy/cucumber) step definitions utilizing
+A set of [Cucumber](https://github.com/cucumber/cucumber) step definitions utilizing
 [Rack-Test](https://github.com/brynary/rack-test) that ease basic
 testing of REST-style APIs using either XML or JSON formats.
 


### PR DESCRIPTION
Cucumber project is now hosted at https://github.com/cucumber/cucumber
