### PR TITLE
Update to the latest classes

### DIFF
--- a/lib/cucumber/api_steps.rb
+++ b/lib/cucumber/api_steps.rb
@@ -44,7 +44,7 @@ When /^I send a (GET|PATCH|POST|PUT|DELETE) request (?:for|to) "([^"]*)"(?: with
   request_opts = {method: request_type.downcase.to_sym}
 
   unless input.nil?
-    if input.class == Cucumber::Ast::Table
+    if input.class == Cucumber::MultilineArgument::DataTable
       request_opts[:params] = input.rows_hash
     else
       request_opts[:input] = StringIO.new input


### PR DESCRIPTION
This removes a deprivation warning that makes the running of tests look
messy. And we want our cucumber warnings to run slick and
professionally.