### PR TITLE
fix "the JSON response should be"

### DIFF
--- a/lib/cucumber/api_steps.rb
+++ b/lib/cucumber/api_steps.rb
@@ -150,7 +150,7 @@ Then /^the JSON response should be:$/ do |json|
   if self.respond_to?(:expect)
     expect(actual).to eq(expected)
   else
-    assert_equal actual, response
+    assert_equal actual, expected
   end
 end
 


### PR DESCRIPTION
basically just a typo. usage of wrong variable made assertion fail always.