### PR TITLE
fix assertion argument order

### DIFF
--- a/lib/cucumber/api_steps.rb
+++ b/lib/cucumber/api_steps.rb
@@ -150,7 +150,7 @@ Then /^the JSON response should be:$/ do |json|
   if self.respond_to?(:expect)
     expect(actual).to eq(expected)
   else
-    assert_equal actual, expected
+    assert_equal expected, actual
   end
 end
 


### PR DESCRIPTION
minitest assertions take the expected
value as first, the actual value as second
argument.