### PR TITLE
fix tests

### DIFF
--- a/features/step_definitions/api_test_steps.rb
+++ b/features/step_definitions/api_test_steps.rb
@@ -37,7 +37,7 @@ Then /^the request headers should be:$/ do |headers|
 end
 
 Then /^I should be authenticated$/ do
-  expect(last_request.env["HTTP_AUTHORIZATION"]).to eq("Basic #{Base64.encode64("joe:god")}")
+  expect(last_request.env["HTTP_AUTHORIZATION"]).to eq("Basic #{Base64.strict_encode64("joe:god")}")
 end
 
 Then /^I should be digest authenticated$/ do


### PR DESCRIPTION
use Base64.strict_encode64 which does not add line feeds every few characters.

see https://ruby-doc.org/stdlib-2.2.0/libdoc/base64/rdoc/Base64.html#method-i-strict_encode64

::strict_encode64 also uses the same #pack logic
as rack-test does inside its #basic_authorize method.

see https://github.com/rack-test/rack-test/blob/72fc72dc15bfd33f45bc13cd134fb5e2c04dbe1e/lib/rack/test.rb#L166

more: https://glaucocustodio.github.io/2014/09/27/a-reminder-about-base64encode64-in-ruby/